### PR TITLE
Greatly improved TypeDSL

### DIFF
--- a/doc/integration/jackson.md
+++ b/doc/integration/jackson.md
@@ -81,7 +81,7 @@ class SomeGenericPojo<T> { /* some body */ }
 fun usage(myData: String) {
     val deserialized1 = myData.deserialize<SomePojo>()
     val deserialized2 = myData deserialize SomePojo::class
-    val deserialized3: SomeGenericPojo<List<String>> = myData deserialize { generic(SomeGenericPojo::class, list<String>()) }
+    val deserialized3 = myData deserialize { generic<SomeGenericPojo<List<String>>>(SomeGenericPojo::class, list<String>()) }
     val deserializedAsJsonNode = myData deserialize JsonNode::class
     
     // if you added json-path as dependency to your project
@@ -102,7 +102,7 @@ class SomeGenericPojo<T> { /* some body */ }
 fun usage(myData: JsonNode) {
     val mapped1 = myData.mapTo<SomePojo>()
     val mapped2 = myData mapTo SomePojo::class
-    val mapped3: SomeGenericPojo<List<String>> = myData mapTo { generic(SomeGenericPojo::class, list<String>()) }
+    val mapped3 = myData mapTo { generic<SomeGenericPojo<List<String>>>(SomeGenericPojo::class, list<String>()) }
     val mappedToJsonNode = myData mapTo JsonNode::class
     
     // if you added json-path as dependency to your project

--- a/doc/integration/jsonpath.md
+++ b/doc/integration/jsonpath.md
@@ -53,7 +53,7 @@ fun usage() {
     // deserialization
     val myResult = simpleQuery castTo ResultPojo::class
     val myResult2: ResultPojo = simpleQuery.castTo()
-    val myResult3: List<Contained> = complexSqlStyle castTo type { list<Contained>() } 
+    val myResult3 = complexSqlStyle castTo type { list<Contained>() } 
 }
 ```
 

--- a/doc/integration/rest-assured/rest.md
+++ b/doc/integration/rest-assured/rest.md
@@ -104,6 +104,7 @@ Types you can use for `as` in complex queries and as type arguments for return t
  - RestAssured's `Response`
  - Any POJO type supported by Jackson
  - If provided TypeDSL or Jackson's `JavaType` - almost any type at all
+ - As bonus for `JavaType` representing `Pair<Int, T>` you'll get a pair of statusCode and body
 
 ##### Note about overriding policy for headers
 

--- a/ktest-integration/ktest-jackson/src/main/kotlin/run/smt/ktest/json/mapping.kt
+++ b/ktest-integration/ktest-jackson/src/main/kotlin/run/smt/ktest/json/mapping.kt
@@ -17,7 +17,7 @@ val mapper = jacksonObjectMapper()
 inline fun <reified T : Any> String.loadAsJson(): T = load().deserialize()
 fun <T : Any> String.loadAsJson(type: JavaType): T = load() deserialize type
 fun <T : Any> String.loadAsJson(type: TypeReference<T>) = load() deserialize type
-fun <T : Any> String.loadAsJson(type: TypeDSL) = load().deserialize<T>(type)
+fun <T : Any> String.loadAsJson(type: TypeDSL<T>) = load().deserialize(type)
 fun String.loadAsJsonTree() = load().deserialize<JsonNode>()
 
 fun Any?.serialize(): ByteArray = mapper.writeValueAsBytes(this)
@@ -31,9 +31,9 @@ infix fun <R : Any> String.deserialize(clazz: KClass<R>) = mapper.readTree(this)
 infix fun <R : Any> ByteArray.deserialize(clazz: KClass<R>) = mapper.readTree(this) mapTo clazz.java
 infix fun <R : Any> InputStream.deserialize(clazz: KClass<R>) = mapper.readTree(this) mapTo clazz.java
 
-infix fun <R : Any> String.deserialize(typeDSL: TypeDSL): R = this deserialize type(typeDSL)
-infix fun <R : Any> ByteArray.deserialize(typeDSL: TypeDSL): R = this deserialize type(typeDSL)
-infix fun <R : Any> InputStream.deserialize(typeDSL: TypeDSL): R = this deserialize type(typeDSL)
+infix fun <R : Any> String.deserialize(typeDSL: TypeDSL<R>): R = this deserialize type(typeDSL)
+infix fun <R : Any> ByteArray.deserialize(typeDSL: TypeDSL<R>): R = this deserialize type(typeDSL)
+infix fun <R : Any> InputStream.deserialize(typeDSL: TypeDSL<R>): R = this deserialize type(typeDSL)
 
 infix fun <R : Any> String.deserialize(clazz: Class<R>) = mapper.readTree(this) mapTo clazz
 infix fun <R : Any> ByteArray.deserialize(clazz: Class<R>) = mapper.readTree(this) mapTo clazz
@@ -50,7 +50,7 @@ infix fun <R : Any> InputStream.deserialize(type: TypeReference<R>) = mapper.rea
 infix fun <R: Any> JsonNode.mapTo(type: TypeReference<R>): R = mapTo(mapper.constructType(type.type))
 infix fun <R: Any> JsonNode.mapTo(resultClass: Class<R>): R = mapTo { simple(resultClass) }
 infix fun <R: Any> JsonNode.mapTo(resultClass: KClass<R>): R = mapTo { simple(resultClass) }
-infix fun <R: Any> JsonNode.mapTo(type: TypeDSL): R = mapTo(type(type))
+infix fun <R: Any> JsonNode.mapTo(type: TypeDSL<R>): R = mapTo(type(type))
 
 infix fun <R> JsonNode.mapTo(type: JavaType): R {
     @Suppress("UNCHECKED_CAST")

--- a/ktest-integration/ktest-jackson/src/main/kotlin/run/smt/ktest/json/type-dsl.kt
+++ b/ktest-integration/ktest-jackson/src/main/kotlin/run/smt/ktest/json/type-dsl.kt
@@ -1,40 +1,58 @@
 package run.smt.ktest.json
 
 import com.fasterxml.jackson.databind.JavaType
-import java.lang.reflect.Type
 import kotlin.reflect.KClass
 
-typealias TypeDSL = TypeBuilder.() -> JavaType
+typealias TypeDSL<T> = TypeBuilder.() -> Typed<T>
 
-fun type(dsl: TypeDSL) = TypeBuilder.dsl()
+@Suppress("unused")
+class Typed<out T> internal constructor(internal val asJavaType: JavaType)
+
+fun type(typed: Typed<*>) = typed.asJavaType
+fun type(dsl: TypeDSL<*>) = type(TypeBuilder.dsl())
+
 object TypeBuilder {
     private val typeFactory = mapper.typeFactory
 
     inline fun <reified T : Any> list() = list(T::class)
     fun <T : Any> list(clazz: KClass<T>) = list(clazz.java)
-    fun <T : Any> list(clazz: Class<T>): JavaType = typeFactory.constructCollectionType(List::class.java, clazz)
-    fun list(type: JavaType): JavaType = typeFactory.constructCollectionType(List::class.java, type)
+    fun <T : Any> list(clazz: Class<T>): Typed<List<T>> = Typed(typeFactory.constructCollectionType(List::class.java, clazz))
+    fun list(type: JavaType): Typed<List<*>> = Typed(typeFactory.constructCollectionType(List::class.java, type))
+    fun <T : Any> list(type: Typed<T>): Typed<List<T>> = Typed(typeFactory.constructCollectionType(List::class.java, type.asJavaType))
 
     inline fun <reified T : Any> set() = set(T::class)
     fun <T : Any> set(clazz: KClass<T>) = set(clazz.java)
-    fun <T : Any> set(clazz: Class<T>): JavaType = typeFactory.constructCollectionType(Set::class.java, clazz)
-    fun set(type: JavaType): JavaType = typeFactory.constructCollectionType(Set::class.java, type)
+    fun <T : Any> set(clazz: Class<T>): Typed<Set<T>> = Typed(typeFactory.constructCollectionType(Set::class.java, clazz))
+    fun set(type: JavaType): Typed<Set<*>> = Typed(typeFactory.constructCollectionType(Set::class.java, type))
+    fun <T: Any> set(type: Typed<T>): Typed<Set<T>> = Typed(typeFactory.constructCollectionType(Set::class.java, type.asJavaType))
 
     inline fun <reified K : Any, reified V : Any> map() = map(K::class, V::class)
     fun <K : Any, V : Any> map(key: KClass<K>, value: KClass<V>) = map(key.java, value.java)
     fun <K : Any, V : Any> map(key: Class<K>, value: KClass<V>) = map(key, value.java)
     fun <K : Any, V : Any> map(key: KClass<K>, value: Class<V>) = map(key.java, value)
-    fun <K : Any, V : Any> map(key: Class<K>, value: Class<V>): JavaType = typeFactory.constructMapType(Map::class.java, key, value)
-    fun map(key: JavaType, value: JavaType): JavaType = typeFactory.constructMapType(Map::class.java, key, value)
+    fun <K : Any, V : Any> map(key: Class<K>, value: Class<V>): Typed<Map<K, V>> = Typed(typeFactory.constructMapType(Map::class.java, key, value))
+    fun <K : Any, V : Any> map(key: Typed<K>, value: Typed<V>): Typed<Map<K, V>> = Typed(typeFactory.constructMapType(Map::class.java, key.asJavaType, value.asJavaType))
+    fun map(key: JavaType, value: JavaType): Typed<Map<*, *>> = Typed(typeFactory.constructMapType(Map::class.java, key, value))
 
-    fun <T : Any> generic(clazz: KClass<T>, vararg parameters: Class<*>) = generic(clazz.java, *parameters)
-    fun <T : Any> generic(clazz: KClass<T>, vararg parameters: KClass<*>) = generic(clazz.java, *parameters)
-    fun <T : Any> generic(clazz: KClass<T>, vararg parameters: JavaType) = generic(clazz.java, *parameters)
-    fun <T : Any> generic(clazz: Class<T>, vararg parameters: KClass<*>) = generic(clazz, *parameters.map(KClass<*>::java).toTypedArray())
-    fun <T : Any> generic(clazz: Class<T>, vararg parameters: Class<*>): JavaType = typeFactory.constructParametricType(clazz, *parameters)
-    fun <T : Any> generic(clazz: Class<T>, vararg parameters: JavaType): JavaType = typeFactory.constructParametricType(clazz, *parameters)
+    fun <T : Any> generic(clazz: KClass<*>, vararg parameters: Class<*>): Typed<T> = generic(clazz.java, *parameters)
+    fun <T : Any> generic(clazz: KClass<*>, vararg parameters: KClass<*>): Typed<T> = generic(clazz.java, *parameters)
+    fun <T : Any> generic(clazz: KClass<*>, vararg parameters: JavaType): Typed<T> = generic(clazz.java, *parameters)
+    fun <T : Any> generic(clazz: Class<*>, vararg parameters: KClass<*>): Typed<T> = generic(clazz, *parameters.map(KClass<*>::java).toTypedArray())
+    fun <T : Any> generic(clazz: KClass<*>, vararg parameters: Typed<*>): Typed<T> = generic(clazz.java, *parameters)
+    fun <T : Any> generic(clazz: Class<*>, vararg parameters: Class<*>): Typed<T> = Typed(typeFactory.constructParametricType(clazz, *parameters))
+    fun <T : Any> generic(clazz: Class<*>, vararg parameters: JavaType): Typed<T> = Typed(typeFactory.constructParametricType(clazz, *parameters))
+    fun <T : Any> generic(clazz: Class<*>, vararg parameters: Typed<*>): Typed<T> = Typed(typeFactory.constructParametricType(clazz, *parameters.map(Typed<*>::asJavaType).toTypedArray()))
 
     inline fun <reified T : Any> simple() = simple(T::class)
     fun <T : Any> simple(clazz: KClass<T>) = simple(clazz.java)
-    fun <T : Any> simple(clazz: Class<T>): JavaType = typeFactory.constructSimpleType(clazz, clazz.typeParameters.map { simple<Any>() }.toTypedArray())
+    fun <T : Any> simple(clazz: Class<T>): Typed<T> = Typed(typeFactory.constructSimpleType(clazz, clazz.typeParameters.map { simple<Any>().asJavaType }.toTypedArray()))
+
+
+    inline fun <reified K : Any, reified V : Any> pair() = pair(K::class, V::class)
+    fun <K : Any, V : Any> pair(key: KClass<K>, value: KClass<V>) = pair(key.java, value.java)
+    fun <K : Any, V : Any> pair(key: Class<K>, value: KClass<V>) = pair(key, value.java)
+    fun <K : Any, V : Any> pair(key: KClass<K>, value: Class<V>) = pair(key.java, value)
+    fun <K : Any, V : Any> pair(key: Class<K>, value: Class<V>): Typed<Pair<K, V>> = Typed(type { generic<Pair<K, V>>(Pair::class, key, value) })
+    fun <K : Any, V : Any> pair(key: Typed<K>, value: Typed<V>): Typed<Pair<K, V>> = Typed(type { generic<Pair<K, V>>(Pair::class, key, value) })
+    fun pair(key: JavaType, value: JavaType): Typed<Pair<*, *>> = Typed(type { generic<Pair<*, *>>(Pair::class, key, value) })
 }

--- a/ktest-integration/ktest-json-matchers/src/test/kotlin/run/smt/ktest/json/matcher/JsonDiffSpec.kt
+++ b/ktest-integration/ktest-json-matchers/src/test/kotlin/run/smt/ktest/json/matcher/JsonDiffSpec.kt
@@ -3,14 +3,17 @@ package run.smt.ktest.json.matcher
 import com.fasterxml.jackson.databind.node.MissingNode
 import com.natpryce.hamkrest.*
 import com.natpryce.hamkrest.assertion.assertThat
+import org.junit.runner.RunWith
 import run.smt.ktest.json.createJsonNode
 import run.smt.ktest.json.loadAsJsonTree
 import run.smt.ktest.json.matcher.api.ComparisonMismatch
 import run.smt.ktest.json.matcher.api.ComparisonPath
 import run.smt.ktest.json.matcher.api.jsonComparator
+import run.smt.ktest.runner.junit4.KTestJUnitRunner
 import run.smt.ktest.specs.WordSpec
 
-class JsonDiffSpec : WordSpec({
+@RunWith(KTestJUnitRunner::class)
+object JsonDiffSpec : WordSpec({
     "JsonComparator" should {
         "return no mismatches for equal JSONs" {
             val firstJson = "simple.json".loadAsJsonTree()

--- a/ktest-integration/ktest-jsonpath/src/main/kotlin/run/smt/ktest/jsonpath/cast-to.kt
+++ b/ktest-integration/ktest-jsonpath/src/main/kotlin/run/smt/ktest/jsonpath/cast-to.kt
@@ -3,14 +3,11 @@ package run.smt.ktest.jsonpath
 import com.fasterxml.jackson.databind.JavaType
 import com.jayway.jsonpath.DocumentContext
 import com.jayway.jsonpath.TypeRef
-import run.smt.ktest.json.TypeDSL
-import run.smt.ktest.json.createJsonNode
-import run.smt.ktest.json.type
-import run.smt.ktest.json.mapTo
+import run.smt.ktest.json.*
 import kotlin.reflect.KClass
 
 inline fun <reified T : Any> DocumentContext.castTo() = this castTo T::class
 infix fun <T : Any> DocumentContext.castTo(clazz: KClass<T>) = createJsonNode(json()) mapTo clazz
 infix fun <T : Any> DocumentContext.castTo(type: TypeRef<T>) = read("$", type)
 infix fun <T : Any> DocumentContext.castTo(type: JavaType): T = createJsonNode(json()) mapTo type
-infix fun <T : Any> DocumentContext.castTo(typeDSL: TypeDSL): T = this castTo type(typeDSL)
+infix fun <T : Any> DocumentContext.castTo(typeDSL: TypeDSL<T>): T = this castTo type(typeDSL)

--- a/ktest-integration/ktest-jsonpath/src/main/kotlin/run/smt/ktest/jsonpath/subtree/extraction.kt
+++ b/ktest-integration/ktest-jsonpath/src/main/kotlin/run/smt/ktest/jsonpath/subtree/extraction.kt
@@ -8,7 +8,7 @@ fun extractSubtree(dc: DocumentContext, ignoreMissing: Boolean = false, dsl: Sub
 
 fun extractSubtree(dc: DocumentContext, spec: SubtreeSpec, ignoreMissing: Boolean = false): DocumentContext {
     val resolvableDc = dc.asResolvableContext(ignoreMissing)
-    val allPaths = resolvableDc["$..*"].castTo<List<String>> { list<String>() }.asSequence()
+    val allPaths = resolvableDc["$..*"].castTo { list<String>() }.asSequence()
 
     val preservedPaths = resolvePaths(spec, resolvableDc)
 

--- a/ktest-integration/ktest-jsonpath/src/main/kotlin/run/smt/ktest/jsonpath/subtree/helpers.kt
+++ b/ktest-integration/ktest-jsonpath/src/main/kotlin/run/smt/ktest/jsonpath/subtree/helpers.kt
@@ -8,7 +8,7 @@ import run.smt.ktest.jsonpath.copy
 internal fun resolvePaths(spec: SubtreeSpec, resolvableContext: DocumentContext): Set<String> {
     return spec.asSequence()
         .map { it.applyOn(resolvableContext) }
-        .map { it.castTo<List<String>> { list<String>() } }
+        .map { it.castTo { list<String>() } }
         .flatMap { it.asSequence() }
         .toSet()
 }

--- a/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonPathExtractionSpec.kt
+++ b/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonPathExtractionSpec.kt
@@ -3,9 +3,12 @@ package run.smt.ktest.jsonpath
 import com.jayway.jsonpath.DocumentContext
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import org.junit.runner.RunWith
+import run.smt.ktest.runner.junit4.KTestJUnitRunner
 import run.smt.ktest.specs.WordSpec
 
-class JsonPathExtractionSpec : WordSpec({
+@RunWith(KTestJUnitRunner::class)
+object JsonPathExtractionSpec : WordSpec({
     val jsonPath = "find.json".loadAsJsonPath()
 
     "DocumentContext[]" should {

--- a/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonSubtreeAdditionSpec.kt
+++ b/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonSubtreeAdditionSpec.kt
@@ -3,11 +3,14 @@ package run.smt.ktest.jsonpath
 import com.jayway.jsonpath.JsonPath
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import org.junit.runner.RunWith
 import run.smt.ktest.jsonpath.subtree.put
+import run.smt.ktest.runner.junit4.KTestJUnitRunner
 import run.smt.ktest.specs.WordSpec
 import run.smt.ktest.util.text.stripMargin
 
-class JsonSubtreeAdditionSpec : WordSpec({
+@RunWith(KTestJUnitRunner::class)
+object JsonSubtreeAdditionSpec : WordSpec({
     val json = """
         | {
         |   "outer" : {
@@ -31,7 +34,7 @@ class JsonSubtreeAdditionSpec : WordSpec({
 
                     "overridden" at "inner.leaf"
                 }
-            }.castTo<Map<String, Any>> { map<String, Any>() }
+            }.castTo { map<String, Any>() }
 
             assertThat(actual, equalTo<Map<String, Any>>(mapOf(
                 "outer" to mapOf(
@@ -48,7 +51,7 @@ class JsonSubtreeAdditionSpec : WordSpec({
             val jp = JsonPath.parse(json)
             val actual = jp.put(force = true) {
                 "truly leaf this time" at "outer.inner.leaf.trulyLeaf"
-            }.castTo<Map<String, Any>> { map<String, Any>() }
+            }.castTo { map<String, Any>() }
 
             assertThat(actual, equalTo<Map<String, Any>>(mapOf(
                 "outer" to mapOf(
@@ -65,7 +68,7 @@ class JsonSubtreeAdditionSpec : WordSpec({
             val jp = JsonPath.parse(json)
             val actual = jp.put {
                 "hello" at "outer"
-            }.castTo<Map<String, Any>> { map<String, Any>() }
+            }.castTo { map<String, Any>() }
 
             assertThat(actual, equalTo(mapOf<String, Any>("outer" to "hello")))
         }
@@ -76,7 +79,7 @@ class JsonSubtreeAdditionSpec : WordSpec({
                 "otherBranch.inner" {
                     "world" at "hello"
                 }
-            }.castTo<Map<String, Any>> { map<String, Any>() }
+            }.castTo { map<String, Any>() }
 
             assertThat(actual, equalTo(mapOf<String, Any>(
                 "outer" to mapOf("inner" to mapOf("leaf" to "leaf")),

--- a/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonSubtreeExtractionSpec.kt
+++ b/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonSubtreeExtractionSpec.kt
@@ -5,13 +5,16 @@ import com.jayway.jsonpath.PathNotFoundException
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
+import org.junit.runner.RunWith
 import run.smt.ktest.jsonpath.criteria.filter
 import run.smt.ktest.jsonpath.subtree.createSubtree
 import run.smt.ktest.jsonpath.subtree.extractSubtree
+import run.smt.ktest.runner.junit4.KTestJUnitRunner
 import run.smt.ktest.specs.WordSpec
 import run.smt.ktest.util.text.stripMargin
 
-class JsonSubtreeExtractionSpec : WordSpec({
+@RunWith(KTestJUnitRunner::class)
+object JsonSubtreeExtractionSpec : WordSpec({
     val subtreeWithMissing = createSubtree {
         + "config.apps.app0.app2" {
             + "core" {

--- a/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonSubtreeRemovalSpec.kt
+++ b/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonSubtreeRemovalSpec.kt
@@ -2,10 +2,13 @@ package run.smt.ktest.jsonpath
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import org.junit.runner.RunWith
 import run.smt.ktest.jsonpath.subtree.remove
+import run.smt.ktest.runner.junit4.KTestJUnitRunner
 import run.smt.ktest.specs.WordSpec
 
-class JsonSubtreeRemovalSpec : WordSpec({
+@RunWith(KTestJUnitRunner::class)
+object JsonSubtreeRemovalSpec : WordSpec({
     "DocumentContext remove" should {
         "correctly drop specified nodes" {
             val jp = "for-subtree.json".loadAsJsonPath()

--- a/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonSubtreeRenameSpec.kt
+++ b/ktest-integration/ktest-jsonpath/src/test/kotlin/run/smt/ktest/jsonpath/JsonSubtreeRenameSpec.kt
@@ -3,11 +3,14 @@ package run.smt.ktest.jsonpath
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
+import org.junit.runner.RunWith
 import run.smt.ktest.json.loadAsJson
 import run.smt.ktest.jsonpath.subtree.rename
+import run.smt.ktest.runner.junit4.KTestJUnitRunner
 import run.smt.ktest.specs.WordSpec
 
-class JsonSubtreeRenameSpec : WordSpec({
+@RunWith(KTestJUnitRunner::class)
+object JsonSubtreeRenameSpec : WordSpec({
     "DocumentContext rename" should {
         "correctly rename fields" {
             val jp = "for-subtree.json".loadAsJsonPath()
@@ -23,7 +26,7 @@ class JsonSubtreeRenameSpec : WordSpec({
                         "core.datasources.app2.url" to "URL"
                     }
                 }
-            }.castTo { map<String, Any>() }, equalTo("for-subtree-afterRename.json".loadAsJson<Map<String, Any>> { map<String, Any>() }))
+            }.castTo { map<String, Any>() }, equalTo("for-subtree-afterRename.json".loadAsJson { map<String, Any>() }))
         }
 
         "do nothing if no fields for rename specified" {
@@ -32,7 +35,7 @@ class JsonSubtreeRenameSpec : WordSpec({
 
             assertThat(
                 jp.rename().castTo { map<String, Any>() },
-                equalTo(untouched.castTo<Map<String, Any>> { map<String, Any>() })
+                equalTo(untouched.castTo { map<String, Any>() })
             )
         }
 

--- a/ktest-integration/ktest-rest/src/main/kotlin/run/smt/ktest/rest/api/SimpleRequests.kt
+++ b/ktest-integration/ktest-rest/src/main/kotlin/run/smt/ktest/rest/api/SimpleRequests.kt
@@ -92,24 +92,24 @@ interface SimpleRequests : Deserialization, ComplexQueriesBuilder {
 
     // kTest JSON TypeDSLs
 
-    fun <T : Any> String.GET(builder: TypeDSL, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
+    fun <T : Any> String.GET(vararg parameters: RequestElement, ignoreStatusCode: Boolean = false, builder: TypeDSL<T>): T =
         GET(clazz = type(builder), parameters = *parameters, ignoreStatusCode = ignoreStatusCode)
 
-    fun <T : Any> String.POST(builder: TypeDSL, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
+    fun <T : Any> String.POST(vararg parameters: RequestElement, ignoreStatusCode: Boolean = false, builder: TypeDSL<T>): T =
         POST(clazz = type(builder), parameters = *parameters, ignoreStatusCode = ignoreStatusCode)
 
-    fun <T : Any> String.PUT(builder: TypeDSL, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
+    fun <T : Any> String.PUT(vararg parameters: RequestElement, ignoreStatusCode: Boolean = false, builder: TypeDSL<T>): T =
         PUT(clazz = type(builder), parameters = *parameters, ignoreStatusCode = ignoreStatusCode)
 
-    fun <T : Any> String.HEAD(builder: TypeDSL, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
+    fun <T : Any> String.HEAD(vararg parameters: RequestElement, ignoreStatusCode: Boolean = false, builder: TypeDSL<T>): T =
         HEAD(clazz = type(builder), parameters = *parameters, ignoreStatusCode = ignoreStatusCode)
 
-    fun <T : Any> String.OPTIONS(builder: TypeDSL, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
+    fun <T : Any> String.OPTIONS(vararg parameters: RequestElement, ignoreStatusCode: Boolean = false, builder: TypeDSL<T>): T =
         OPTIONS(clazz = type(builder), parameters = *parameters, ignoreStatusCode = ignoreStatusCode)
 
-    fun <T : Any> String.PATCH(builder: TypeDSL, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
+    fun <T : Any> String.PATCH(vararg parameters: RequestElement, ignoreStatusCode: Boolean = false, builder: TypeDSL<T>): T =
         PATCH(clazz = type(builder), parameters = *parameters, ignoreStatusCode = ignoreStatusCode)
 
-    fun <T : Any> String.DELETE(builder: TypeDSL, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
+    fun <T : Any> String.DELETE(vararg parameters: RequestElement, ignoreStatusCode: Boolean = false, builder: TypeDSL<T>): T =
         DELETE(clazz = type(builder), parameters = *parameters, ignoreStatusCode = ignoreStatusCode)
 }

--- a/ktest-integration/ktest-resttest/src/main/kotlin/run/smt/ktest/resttest/api/RestTestDefinition.kt
+++ b/ktest-integration/ktest-resttest/src/main/kotlin/run/smt/ktest/resttest/api/RestTestDefinition.kt
@@ -83,10 +83,10 @@ interface RestTestDefinition<out U : UrlProvider> : RequestElementBuilder {
         }
     }
 
-    fun <T : Any> expect(type: TypeDSL, expectation: Expectation<T>) = expect(type(type), expectation)
+    fun <T : Any> expect(type: TypeDSL<T>, expectation: Expectation<T>) = expect(type(type), expectation)
 
     fun <T : Any> expect(resultType: KClass<T>, expectation: StatusCodeAwareExpectation<T>)
     fun <T : Any> expect(type: JavaType, expectation: StatusCodeAwareExpectation<T>)
-    fun <T : Any> expect(type: TypeDSL, expectation: StatusCodeAwareExpectation<T>) = expect(type(type), expectation)
+    fun <T : Any> expect(type: TypeDSL<T>, expectation: StatusCodeAwareExpectation<T>) = expect(type(type), expectation)
 }
 

--- a/sample/src/test/kotlin/rest/SimpleRestRequestsSpec.kt
+++ b/sample/src/test/kotlin/rest/SimpleRestRequestsSpec.kt
@@ -1,0 +1,130 @@
+package rest
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.restassured.response.Response
+import mockServer
+import org.junit.runner.RunWith
+import org.mockserver.model.Header
+import org.mockserver.model.HttpRequest
+import org.mockserver.model.HttpResponse
+import run.smt.ktest.json.deserialize
+import run.smt.ktest.json.type
+import run.smt.ktest.rest.rest
+import run.smt.ktest.runner.junit4.KTestJUnitRunner
+import run.smt.ktest.specs.AllureSpec
+import java.io.InputStream
+
+data class SamplePojo(val hello: String)
+
+@RunWith(KTestJUnitRunner::class)
+object SimpleRestRequestsSpec : AllureSpec({
+    feature("REST usage") {
+        story("simple requests") {
+            case("GET with typeDSL") {
+                val response = rest {
+                    "/rest/simple".GET(queryParam("simpleRequest", "simpleRequest")) { map<String, String>() }
+                }
+
+                assertThat(response, equalTo(mapOf("hello" to "world")))
+            }
+
+            case("PUT with reified deserialization") {
+                val response: SamplePojo = rest {
+                    "/rest/simple".PUT(
+                        header("x-my-company-header", "ktest")
+                    )
+                }
+
+                assertThat(response, equalTo(SamplePojo("world")))
+            }
+
+            case("POST with explicit deserialization") {
+                val myData = SamplePojo("world")
+
+                val response = rest {
+
+                    "/rest/{type}".POST(
+                        SamplePojo::class,
+                        pathParam("type", "simple"),
+                        body(myData)
+                    )
+                }
+
+                assertThat(response, equalTo(myData))
+            }
+
+            case("PATCH with deserialization as string") {
+                val response = rest {
+                    "/rest/simple".PATCH<String>()
+                }
+
+                assertThat(response deserialize { map<String, String>() }, equalTo(mapOf("hello" to "world")))
+            }
+
+            case("DELETE with deserialization as InputStream") {
+                val response = rest {
+                    "/rest/simple".DELETE<InputStream>()
+                }
+
+                assertThat(response deserialize { map<String, String>() }, equalTo(mapOf("hello" to "world")))
+            }
+
+            case("GET with deserialization as Pair(statusCode, data) and failure status code") {
+
+                val (statusCode, response) = rest {
+                    // here is how you can nicely mix named parameters, varargs and lambda at the same time!
+                    "/rest/simple".GET(
+                        queryParam("fail", "true"),
+                        ignoreStatusCode = true
+                    ) { pair(simple<Int>(), map<String, String>()) }
+                }
+
+                assertThat(statusCode, equalTo(418))
+                assertThat(response, equalTo(mapOf("hello" to "world")))
+            }
+        }
+    }
+
+    beforeAll {
+        val contentType = Header.header("Content-Type", "application/json; charset=utf-8")
+        val body = """
+                    {
+                        "hello": "world"
+                    }
+                """.trimIndent()
+
+        mockServer.`when`(
+            HttpRequest.request("/rest/simple")
+                .withMethod("GET")
+                .withQueryStringParameter("simpleRequest", "simpleRequest")
+        ).respond(
+            HttpResponse.response(body).withHeader(contentType)
+        )
+
+        mockServer.`when`(
+            HttpRequest.request("/rest/simple")
+                .withMethod("PUT")
+                .withHeader("x-my-company-header", "ktest")
+        ).respond(
+            HttpResponse.response(body).withHeader(contentType)
+        )
+
+        mockServer.`when`(
+            HttpRequest.request("/rest/simple")
+                .withMethod("POST")
+        ).callback { HttpResponse.response(it.bodyAsString).withHeader(contentType) }
+
+        mockServer.`when`(
+            HttpRequest.request("/rest/simple").withMethod("PATCH")
+        ).respond(HttpResponse.response(body).withHeader(contentType))
+
+        mockServer.`when`(
+            HttpRequest.request("/rest/simple").withMethod("DELETE")
+        ).respond(HttpResponse.response(body).withHeader(contentType))
+
+        mockServer.`when`(
+            HttpRequest.request("/rest/simple").withMethod("GET").withQueryStringParameter("fail", "true")
+        ).respond(HttpResponse.response(body).withHeader(contentType).withStatusCode(418))
+    }
+})


### PR DESCRIPTION
Greatly improved TypeDSL - now it is typed, which allows us to force Kotlin into infer most of the types (except for arbitrary generics, which became a little bit uglier...)

Also added samples for RestAssured Core Integration, but only for simple requests (#22)