### PR TITLE
Path param issue

### DIFF
--- a/ktest-integration/ktest-rest/src/main/kotlin/run/smt/ktest/rest/api/RequestElement.kt
+++ b/ktest-integration/ktest-rest/src/main/kotlin/run/smt/ktest/rest/api/RequestElement.kt
@@ -8,12 +8,12 @@ import com.fasterxml.jackson.databind.JsonNode
 sealed class RequestElement {
     fun flatten(): List<RequestElement> = if (this is CompositeParameter) elements.flatMap { it.flatten() } else listOf(this)
 
-    class Header internal constructor(val name: String, val value: String) : RequestElement()
-    class QueryParameter internal constructor(val name: String, val value: Any?) : RequestElement()
-    class Body internal constructor(val data: Any?) : RequestElement()
-    class PathParameter internal constructor(val name: String, val value: String) : RequestElement()
+    data class Header internal constructor(val name: String, val value: String) : RequestElement()
+    data class QueryParameter internal constructor(val name: String, val value: Any?) : RequestElement()
+    data class Body internal constructor(val data: Any?) : RequestElement()
+    data class PathParameter internal constructor(val name: String, val value: String) : RequestElement()
 
-    internal class CompositeParameter(val elements: List<RequestElement>) : RequestElement()
+    internal data class CompositeParameter(val elements: List<RequestElement>) : RequestElement()
 }
 
 /**
@@ -29,12 +29,14 @@ interface RequestElementBuilder {
     fun queryParam(name: String): RequestElement = queryParam(name, true)
     fun queryParams(params: List<Pair<String, Any?>>): RequestElement = RequestElement.CompositeParameter(params.map { (n, v) -> queryParam(n, v) })
     fun queryParams(params: Map<String, Any?>): RequestElement = RequestElement.CompositeParameter(params.map { (n, v) -> queryParam(n, v) })
+    fun queryParams(vararg params: Pair<String, Any?>): RequestElement = queryParams(params.toList())
 
     fun pathParam(pathParam: Pair<String, Any>): RequestElement = pathParams(listOf(pathParam))
     fun pathParam(name: String, value: String): RequestElement = RequestElement.PathParameter(name, value)
     fun pathParam(name: String, value: Long): RequestElement = RequestElement.PathParameter(name, value.toString())
     fun pathParam(name: String, value: Int): RequestElement = RequestElement.PathParameter(name, value.toString())
     fun pathParams(params: List<Pair<String, Any>>): RequestElement = RequestElement.CompositeParameter(params.map { (n, v) -> genericPathParam(n, v) })
+    fun pathParams(vararg params: Pair<String, Any>): RequestElement = pathParams(params.toList())
     fun pathParams(params: Map<String, Any>): RequestElement = RequestElement.CompositeParameter(params.map { (n, v) -> genericPathParam(n, v) })
 
     fun body(content: Any?): RequestElement = if (content is JsonNode) body(content.toString()) else RequestElement.Body(content)

--- a/ktest-integration/ktest-rest/src/main/kotlin/run/smt/ktest/rest/api/SimpleRequests.kt
+++ b/ktest-integration/ktest-rest/src/main/kotlin/run/smt/ktest/rest/api/SimpleRequests.kt
@@ -34,9 +34,6 @@ private inline fun SimpleRequests.request(parameters: Array<out RequestElement>,
         .query().andReturn()
 }
 
-private fun extractPathParams(parameters: Array<out RequestElement>): Map<String, String> =
-    parameters.asSequence().filterIsInstance<RequestElement.PathParameter>().associate { it.name to it.value }
-
 /**
  * Part of REST DSL for performing simple requests with automatic deserialization to requested type + check for status code
  * to be successful
@@ -45,49 +42,49 @@ interface SimpleRequests : Deserialization, ComplexQueriesBuilder {
     // Plain reflection responses
 
     fun <T : Any> String.GET(clazz: KClass<T>, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { get(this@GET, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { get(this@GET) }
 
     fun <T : Any> String.POST(clazz: KClass<T>, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { post(this@POST, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { post(this@POST) }
 
     fun <T : Any> String.PUT(clazz: KClass<T>, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { put(this@PUT, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { put(this@PUT) }
 
     fun <T : Any> String.HEAD(clazz: KClass<T>, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { head(this@HEAD, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { head(this@HEAD) }
 
     fun <T : Any> String.OPTIONS(clazz: KClass<T>, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { options(this@OPTIONS, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { options(this@OPTIONS) }
 
     fun <T : Any> String.PATCH(clazz: KClass<T>, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { patch(this@PATCH, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { patch(this@PATCH) }
 
     fun <T : Any> String.DELETE(clazz: KClass<T>, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { delete(this@DELETE, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { delete(this@DELETE) }
 
 
     // Jackson's JavaTypes
 
     fun <T : Any> String.GET(clazz: JavaType, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { get(this@GET, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { get(this@GET) }
 
     fun <T : Any> String.POST(clazz: JavaType, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { post(this@POST, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { post(this@POST) }
 
     fun <T : Any> String.PUT(clazz: JavaType, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { put(this@PUT, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { put(this@PUT) }
 
     fun <T : Any> String.HEAD(clazz: JavaType, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { head(this@HEAD, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { head(this@HEAD) }
 
     fun <T : Any> String.OPTIONS(clazz: JavaType, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { options(this@OPTIONS, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { options(this@OPTIONS) }
 
     fun <T : Any> String.PATCH(clazz: JavaType, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { patch(this@PATCH, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { patch(this@PATCH) }
 
     fun <T : Any> String.DELETE(clazz: JavaType, vararg parameters: RequestElement, ignoreStatusCode: Boolean = false): T =
-        request(clazz, parameters, ignoreStatusCode) { delete(this@DELETE, extractPathParams(parameters)) }
+        request(clazz, parameters, ignoreStatusCode) { delete(this@DELETE) }
 
 
     // kTest JSON TypeDSLs

--- a/ktest-integration/ktest-rest/src/main/kotlin/run/smt/ktest/rest/impl/RestAssuredRequestsAdapter.kt
+++ b/ktest-integration/ktest-rest/src/main/kotlin/run/smt/ktest/rest/impl/RestAssuredRequestsAdapter.kt
@@ -34,6 +34,9 @@ internal class RestAssuredRequestsAdapter(
         val queryParameters = flattenedParameters
             .filterIsInstance<RequestElement.QueryParameter>()
             .groupBy({ it.name }, { it.value })
+        val pathParameters = flattenedParameters
+            .filterIsInstance<RequestElement.PathParameter>()
+            .associate { it.name to it.value }
         val body = flattenedParameters.filterIsInstance<RequestElement.Body>().firstOrNull()
 
         // Build new rest assured request specification
@@ -51,6 +54,7 @@ internal class RestAssuredRequestsAdapter(
             if (body != null) {
                 setBody(body.data)
             }
+            addPathParams(pathParameters)
         }
 
         val spec = TestSpecificationImpl(

--- a/sample/src/test/kotlin/resttest/config.kt
+++ b/sample/src/test/kotlin/resttest/config.kt
@@ -8,6 +8,7 @@ import run.smt.ktest.rest.url.createUrlDsl
 import run.smt.ktest.resttest.createRestTestDSL
 
 class Url(config: Config) : UrlProvider {
+    val rest: String = config["rest"]
     val ping: String = config["ping"]
     val simple: String = config["simple"]
     val errorHttpCodes: String = config["error-http-codes"]

--- a/sample/src/test/resources/default.conf
+++ b/sample/src/test/resources/default.conf
@@ -1,6 +1,7 @@
 url {
     backend = "http://localhost:10010"
 
+    rest = rest
     ping = ping
     simple = simple
     error-http-codes = errorHttpCodes


### PR DESCRIPTION
Fixed bug with multiple (and untyped) path parameters related to SimpleRequests missing flattening of request params.
Added some convinient methods for vararg request elements.
Made request elements data classes to obtain toString and friends for free.

#62 done